### PR TITLE
AP_ExternalAHRS: SBG: report satellite count in EKF-as-GNSS mode

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_SBG.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_SBG.cpp
@@ -509,6 +509,11 @@ void AP_ExternalAHRS_SBG::handle_msg(const sbgMessage &msg)
 
                     cached.sensors.gps_data.fix_type = AP_GPS_FixType::FIX_3D;
 
+                    // keep reporting the receiver's satellite count: the raw GPSx_POS
+                    // handler below is skipped in EKF-as-GNSS mode, and a stale count of
+                    // 0 makes EKF3's NSats quality check reject this GPS forever
+                    cached.sensors.gps_data.satellites_in_view = cached.sbg.gnssPos.numSvUsed;
+
                     cached.sensors.gps_data.ned_vel_north = cached.sbg.ekfNav.velocity[0];
                     cached.sensors.gps_data.ned_vel_east = cached.sbg.ekfNav.velocity[1];
                     cached.sensors.gps_data.ned_vel_down = cached.sbg.ekfNav.velocity[2];


### PR DESCRIPTION
## Problem

With `EAHRS_OPTIONS` bit 1 set, i.e. parameter value 2 (SBG uses EKF as GNSS) and the INS in full navigation mode, the driver publishes the fused EKF solution as GPS but never updates `satellites_in_view`: the raw `GPS1_POS` handler that normally sets it is skipped in this mode, so the count stays at 0 indefinitely (the INS typically reaches full nav before the autopilot boots, so the raw handler never runs even once).

EKF3's GPS pre-alignment quality check (`EK3_GPS_CHECK` bit 0, on by default) requires at least 6 satellites, so `gpsGoodToAlign` never passes and GPS aiding never starts, even though the receiver has a good fix and the reported accuracies are excellent.

Observed on a Copter with a Quanta Micro (log available):
- GPS reported a 3D fix with `NSats=0` for the entire time the option was enabled
- "Mode change to LOITER failed: requires position" while flying normally in AltHold
- with `EK3_SRC1_POSZ=3` (GPS height), "PreArm: Need Alt Estimate"
- disabling the option in flight: NSats jumped to 32 immediately and EKF3 reported "is using GPS" within seconds

## Fix

Forward the receiver's satellite count from the cached GNSS position log in the EKF-as-GNSS branch. `GPS1_POS` is still copied into the cache unconditionally (only its forwarding branch is gated), so the value stays current, and both the write and the read happen under the same semaphore.

This matches the other ExternalAHRS drivers (VectorNav, InertialLabs), which always publish the receiver-reported satellite count with GPS data.

Since `gpsGoodToAlign` only gates the start of GPS aiding (in-flight fusion is governed by innovation/timeout logic, and a low count only scales measurement noise), reporting the true count also behaves correctly during genuine GNSS outages: an aligned filter keeps navigating on the fused solution.

## Testing

- SITL Copter build passes
- Traced the failing check chain: driver → `AP_GPS_ExternalAHRS::handle_external` → `num_sats` → `calcGpsGoodToAlign` ("GPS numsats 0 (needs 6)") → `readyToUseGPS` → `PV_AidingMode` stuck at `AID_NONE` → `position_ok()` false
- Flight logs confirm the 0-sat symptom with the option enabled and immediate recovery when disabled

